### PR TITLE
[FIX] Relative path in sendCSS caused the impossibility to be used elsewhere

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -10,7 +10,7 @@ exports.sendView = function() {
 }
 
 exports.sendCSS = function() {
-  send('<link rel="stylesheet" href="../../included/stylesheet.css" />');
+  send('<link rel="stylesheet" href="/argos/_design/argos/_rewrite/included/stylesheet.css" />');
 }
 
 exports.xmlencode = function(data) {

--- a/lists/viewpoint.js
+++ b/lists/viewpoint.js
@@ -1,10 +1,12 @@
 function (head, req) {
+  var util = require("lib/util");
   var hypertopic = require("lib/hypertopic");
   var viewpoint = new hypertopic.Viewpoint();
 
   provides("json", require("lib/util").sendView);
 
   provides("html", function() {
+    util.sendCSS();
     while (row = getRow()) {
       viewpoint.addRow(row.key, row.value);
     }


### PR DESCRIPTION
CSS was included using a relative path and could not be included into a Viewpoint, I switched it to an absolute path which solved the issue. I did not test whether the previous inclusion still works (in lists/Item.js) as I am not sure how to display or even generate a single Item view (no reason not to be fine, though).